### PR TITLE
fix: isolate returns to pool on task error

### DIFF
--- a/lib/src/worker/worker_io.dart
+++ b/lib/src/worker/worker_io.dart
@@ -41,8 +41,7 @@ class WorkerImpl implements Worker {
     _runnableNumber = task.number;
     _result = Completer<Object>();
     _sendPort.send(Message(_execute, task.runnable));
-    final resultValue = await (_result.future as Future<O>);
-    _runnableNumber = null;
+    final resultValue = await (_result.future as Future<O>).whenComplete(() => _runnableNumber = null);
     return resultValue;
   }
 

--- a/test/tests.dart
+++ b/test/tests.dart
@@ -29,6 +29,10 @@ Future<int> isolateTask(String name, int value) async {
   return value * 2;
 }
 
+Future<int> isolateTaskError(String name) {
+  throw Exception('Exception: my custom test exception');
+}
+
 const oneSec = Duration(milliseconds: 1);
 
 Future<void> main() async {
@@ -192,5 +196,20 @@ Future<void> main() async {
     expect(results.length, 2);
     expect(errors.length, 1);
     expect(errors[0], isA<CanceledError>());
+  });
+
+  test('isolatePool - should return the isolate back to pool on error', () async {
+    var completedTasks = 0;
+    for (int i = 0; i < 15; i++) {
+      try {
+        await Executor().execute(arg1: 'test', fun1: isolateTaskError);
+      } catch (e) {
+        // print(e);
+      } finally {
+        // print('completed task #$i');
+        completedTasks++;
+      }
+    }
+    expect(completedTasks, 15);
   });
 }


### PR DESCRIPTION
Issue: isolate was not returned to pool when task was executed with errors. This was because `_runnableNumber` was not being set to null on task exceptions. This fixes it. Added tests too.