### PR TITLE
[IMPROVEMENT] Update task completion progress in isolate

### DIFF
--- a/lib/src/model/arguments_send_port.dart
+++ b/lib/src/model/arguments_send_port.dart
@@ -1,0 +1,16 @@
+
+import 'package:worker_manager/src/port/send_port.dart';
+
+class ArgumentsSendPort<A> {
+  final SendPort? sendPort;
+  final A argument;
+
+  ArgumentsSendPort(this.argument, {this.sendPort});
+
+  ArgumentsSendPort copyWith({A? argument, SendPort? sendPort}) {
+    return ArgumentsSendPort(
+      argument ?? this.argument,
+      sendPort: sendPort ?? this.sendPort
+    );
+  }
+}

--- a/lib/src/model/value_update.dart
+++ b/lib/src/model/value_update.dart
@@ -1,0 +1,6 @@
+
+class ValueUpdate<T> {
+  final T value;
+
+  ValueUpdate(this.value);
+}

--- a/lib/src/port/send_port.dart
+++ b/lib/src/port/send_port.dart
@@ -1,0 +1,2 @@
+
+export 'send_port_io.dart' if (dart.library.html) 'send_port_web.dart';

--- a/lib/src/port/send_port_io.dart
+++ b/lib/src/port/send_port_io.dart
@@ -1,0 +1,2 @@
+
+export 'dart:isolate' show SendPort;

--- a/lib/src/port/send_port_web.dart
+++ b/lib/src/port/send_port_web.dart
@@ -1,0 +1,4 @@
+
+class SendPort {
+  void send(Object? message) {}
+}

--- a/lib/src/scheduling/executor.dart
+++ b/lib/src/scheduling/executor.dart
@@ -16,6 +16,7 @@ abstract class Executor {
     Fun4<A, B, C, D, O> fun4,
     WorkPriority priority = WorkPriority.high,
     bool fake = false,
+    OnUpdateProgressCallback? onUpdateProgress
   });
 
   void pausePool();
@@ -77,6 +78,7 @@ class _Executor implements Executor {
     Fun4<A, B, C, D, O>? fun4,
     WorkPriority priority = WorkPriority.high,
     bool fake = false,
+    OnUpdateProgressCallback? onUpdateProgress
   }) {
     final task = Task(
       _taskNumber.toInt(),
@@ -91,6 +93,7 @@ class _Executor implements Executor {
         fun4: fun4,
       ),
       workPriority: priority,
+      onUpdateProgress: onUpdateProgress
     );
 
     Cancelable<O> executing() {

--- a/lib/src/scheduling/task.dart
+++ b/lib/src/scheduling/task.dart
@@ -2,17 +2,20 @@ import 'dart:async';
 import 'runnable.dart';
 
 enum WorkPriority { immediately, veryHigh, high, highRegular, regular, almostLow, low }
+typedef OnUpdateProgressCallback = Function(Object value);
 
 class Task<A, B, C, D, O> implements Comparable<Task<A, B, C, D, O>> {
   final Runnable<A, B, C, D, O> runnable;
   final resultCompleter = Completer<O>();
   final int number;
   final WorkPriority workPriority;
+  final OnUpdateProgressCallback? onUpdateProgress;
 
   Task(
     this.number, {
     required this.runnable,
     this.workPriority = WorkPriority.high,
+    this.onUpdateProgress
   });
 
   @override

--- a/lib/worker_manager.dart
+++ b/lib/worker_manager.dart
@@ -1,6 +1,10 @@
 library worker_manager;
 
 export 'src/scheduling/task.dart' show WorkPriority;
+export 'src/scheduling/task.dart' show OnUpdateProgressCallback;
+export 'src/model/arguments_send_port.dart';
+export 'src/model/value_update.dart';
+export 'src/port/send_port.dart';
 
 import 'dart:async';
 import 'dart:collection';

--- a/test/update_task_completion_progress_test.dart
+++ b/test/update_task_completion_progress_test.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:worker_manager/worker_manager.dart';
+
+void main() async {
+  late Executor executor;
+  late StreamController controller;
+
+  setUp(() async {
+    executor = Executor();
+    controller = StreamController.broadcast();
+
+    await executor.warmUp(log: true);
+  });
+
+  tearDown(() {
+    controller.close();
+  });
+
+  group('update_task_completion_progress test', () {
+    test('onUpdateProgress should get value from sendPort', () async {
+      var stream = controller.stream;
+      final totalTitle = 'Total current: ';
+
+      final result = await executor.execute(
+          arg1: ArgumentsSendPort(totalTitle),
+          fun1: (args) => isolateTask(args),
+          onUpdateProgress: (value) {
+            print('onUpdateProgress: $value');
+            if (value is int) {
+              controller.add(value);
+            }
+          });
+
+      stream.listen((event) {
+        print('stream::listen:Event: $event');
+        expect([1, 2, 3, 4, 5], containsValue(event));
+      });
+
+      expect(result, 15);
+    });
+  });
+}
+
+Future<int> isolateTask(dynamic arguments) async {
+  if (arguments is! ArgumentsSendPort) {
+    return 0;
+  }
+
+  var count = 0;
+  var sum = 0;
+
+  while(count < 5) {
+    count++;
+    await Future.delayed(const Duration(milliseconds: 100));
+    sum += count;
+
+    arguments.sendPort?.send(ValueUpdate(count));
+  }
+
+  return sum;
+}


### PR DESCRIPTION
### Issues

I want to update task completion progress in isolate

### Solution

1. I pass the generated isolate's `SendPort` object to my task handler as the first parameter.
```dart
class ArgumentsSendPort<A> {
   final SendPort? sendPort;
   final A argument;
}
```
2. I create a `ValueUpdate` send object containing the current value of the process.
```dart
class ValueUpdate<T> {
   final T value;
   ValueUpdate(this.value);
}
```
3. I send `ValueUpdate` through `SendPort` every time a partial task is done.
```dart
sendPort.send(ValueUpdate(value));
```
4. Listen to it in the `ReceivePort` of the main isolate
```dart
_receivePort.listen((message) {
  if (message is ValueUpdate) {
    _onUpdateProgress.call(message.value);
  }
}
```

### UnitTest Result

<img width="811" alt="Screen Shot 2022-07-06 at 11 52 05" src="https://user-images.githubusercontent.com/80730648/177471638-ac10b441-a10f-47bc-b6f3-1160a0151dff.png">

