### PR TITLE
Fix conditional import

### DIFF
--- a/lib/worker_manager.dart
+++ b/lib/worker_manager.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 import 'package:worker_manager/src/cancelable/cancelable.dart';
 import 'package:worker_manager/src/number_of_processors/processors_io.dart'
-    if (dart.library.web) 'package:worker_manager/src/number_of_processors/processors_web.dart';
+    if (dart.library.html) 'package:worker_manager/src/number_of_processors/processors_web.dart';
 import 'package:worker_manager/src/scheduling/task.dart';
 import 'package:worker_manager/src/scheduling/work_priority.dart';
 import 'package:worker_manager/src/worker/worker.dart';


### PR DESCRIPTION
`dart.library.web` is not a valid conditional variable.
Changed to `dart.library.html`.

It will break all web app at startup because of calling numberOfProcessor via `io.Platform`. And native app will always be 1 processor(which is actually for web).